### PR TITLE
Added createdAt filter to query

### DIFF
--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -96,6 +96,13 @@ export const getOrgs = async (req, res) => {
 			updated_at: {$lte: new Date(query.lastUpdated)}
 		});
 	}
+
+	if (query.createdAt) {
+		dbQuery = Object.assign(dbQuery, {
+			created_at: {$lte: new Date(query.createdAt)}
+		});
+	}
+
 	await Organization.find(dbQuery)
 		.sort(obj)
 		.skip(offset)


### PR DESCRIPTION
## Description

Added feature to filter organizations by created_at date in control-panel.
This is the query portion on the catalog-api side.

- Asana ticket: https://app.asana.com/0/1132189118126148/1199528219905010

## PR Checklist

- [X] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [X] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. Login to Control Panel.
2. Under Filter Organizations, enter a date or use the date picker to populate the Created Before field
3. Click Search
4. Click View next to one of the returned results to view the organization
5. Verify that the Created At date is on or before the date selected.
