### PR TITLE
Feature/1200453899422605/expand date filters

### DIFF
--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -85,27 +85,17 @@ export const getOrgs = async (req, res) => {
 			}
 		}
 	}
-	// if (query.lastVerified) {
-	// 	dbQuery = Object.assign(dbQuery, {
-	// 		verified_at: {$lte: new Date(query.lastVerified)}
-	// 	});
-	// }
 
 	if (query.lastVerified) {
 		if (query.lastVerifiedEnd) {
+			const lastVerifiedDateString = JSON.stringify(query.lastVerified);
+			const lastVerifiedEndDateString = JSON.stringify(query.lastVerifiedEnd);
+
 			dbQuery = Object.assign(dbQuery, {
-				$and: [
-					{
-						verified_at: {
-							$lte: new Date(query.lastVerifiedEnd)
-						}
-					},
-					{
-						verified_at: {
-							$gte: new Date(query.lastVerified)
-						}
-					}
-				]
+				verified_at: {
+					$gte: JSON.parse(lastVerifiedDateString),
+					$lte: JSON.parse(lastVerifiedEndDateString)
+				}
 			});
 		} else {
 			dbQuery = Object.assign(dbQuery, {
@@ -115,10 +105,41 @@ export const getOrgs = async (req, res) => {
 	}
 
 	if (query.lastUpdated) {
-		dbQuery = Object.assign(dbQuery, {
-			updated_at: {$lte: new Date(query.lastUpdated)}
-		});
+		if (query.lastUpdatedEnd) {
+			const lastUpdatedDateString = JSON.stringify(query.lastUpdated);
+			const lastUpdatedEndDateString = JSON.stringify(query.lastUpdatedEnd);
+
+			dbQuery = Object.assign(dbQuery, {
+				updated_at: {
+					$gte: JSON.parse(lastUpdatedDateString),
+					$lte: JSON.parse(lastUpdatedEndDateString)
+				}
+			});
+		} else {
+			dbQuery = Object.assign(dbQuery, {
+				updated_at: {$lte: new Date(query.lastUpdated)}
+			});
+		}
 	}
+
+	if (query.createdAt) {
+		if (query.createdAtEnd) {
+			const createdAtDateString = JSON.stringify(query.createdAt);
+			const createdAtEndDateString = JSON.stringify(query.createdAtEnd);
+
+			dbQuery = Object.assign(dbQuery, {
+				created_at: {
+					$gte: JSON.parse(createdAtDateString),
+					$lte: JSON.parse(createdAtEndDateString)
+				}
+			});
+		} else {
+			dbQuery = Object.assign(dbQuery, {
+				created_at: {$lte: new Date(query.createdAt)}
+			});
+		}
+	}
+
 	console.log(dbQuery);
 
 	await Organization.find(dbQuery)

--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -85,10 +85,33 @@ export const getOrgs = async (req, res) => {
 			}
 		}
 	}
+	// if (query.lastVerified) {
+	// 	dbQuery = Object.assign(dbQuery, {
+	// 		verified_at: {$lte: new Date(query.lastVerified)}
+	// 	});
+	// }
+
 	if (query.lastVerified) {
-		dbQuery = Object.assign(dbQuery, {
-			verified_at: {$lte: new Date(query.lastVerified)}
-		});
+		if (query.lastVerifiedEnd) {
+			dbQuery = Object.assign(dbQuery, {
+				$and: [
+					{
+						verified_at: {
+							$lte: new Date(query.lastVerifiedEnd)
+						}
+					},
+					{
+						verified_at: {
+							$gte: new Date(query.lastVerified)
+						}
+					}
+				]
+			});
+		} else {
+			dbQuery = Object.assign(dbQuery, {
+				verified_at: {$lte: new Date(query.lastVerified)}
+			});
+		}
 	}
 
 	if (query.lastUpdated) {
@@ -96,6 +119,8 @@ export const getOrgs = async (req, res) => {
 			updated_at: {$lte: new Date(query.lastUpdated)}
 		});
 	}
+	console.log(dbQuery);
+
 	await Organization.find(dbQuery)
 		.sort(obj)
 		.skip(offset)
@@ -316,7 +341,7 @@ export let sendOrgOwnerStatus = async (req, res, next) => {
 	switch (ownerStatus) {
 		case 'approve':
 			subject = `You are now affiliated with ${org} on AsylumConnect`;
-			message = `Thank you for requesting to join ${org} on the AsylumConnect Catalog (https://asylumconnect.org). Our team has approved your request and your AsylumConnect user account is now connected to ${org}\'s profile page on AsylumConnect.\n\nBest,\nThe AsylumConnect Team`;
+			message = `Thank you for requesting to join ${org} on the AsylumConnect Catalog (https://asylumconnect.org). Our team has approved your request and your AsylumConnect user account is now connected to ${org}'s profile page on AsylumConnect.\n\nBest,\nThe AsylumConnect Team`;
 			html = `<html>Thank you for requesting to join ${org} on the <a href='https://asylumconnect.org'>AsylumConnect Catalog</a>. Our team has approved your request and your AsylumConnect user account is now connected to ${org}'s profile page on AsylumConnect.<br/><br/>Best,<br/>The AsylumConnect Team</html>`;
 			break;
 		case 'deny':

--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -138,6 +138,7 @@ export const getOrgs = async (req, res) => {
 				created_at: {$lte: new Date(query.createdAt)}
 			});
 		}
+	}
 
 	await Organization.find(dbQuery)
 		.sort(obj)

--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -140,8 +140,6 @@ export const getOrgs = async (req, res) => {
 		}
 	}
 
-	console.log(dbQuery);
-
 	await Organization.find(dbQuery)
 		.sort(obj)
 		.skip(offset)


### PR DESCRIPTION
## Description

Updated catalog-api to accept a date range in the query and filter organizations based on the date range, for last_verified, last_updated and created_at dates.

- Asana ticket:  https://app.asana.com/0/1132189118126148/1200453899422605

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [x] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [x] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test

1. Login to Control Panel.
2. Under Filter Organizations, enter a date or use the date picker to populate either the first date field or both date fields under Last Verified, Last Updated or Created At.
3. Click Search
4. Click View next to one of the returned results to view the organization
5. If only the first date field was used, verify that the returned results have a [Last Verified, Last Updated or Created At] dates older than the date entered.  If both date fields for a criteria were used, verify that the returned results have a [Last Verified, Last Updated or Created At] date between the date values entered.
