### PR TITLE
default geocode to 0 if lat/long not set

### DIFF
--- a/cypress/integration/organization_spec.js
+++ b/cypress/integration/organization_spec.js
@@ -392,19 +392,21 @@ describe('Organization Routers', () => {
 						'Organization must have a primary location'
 					);
 				});
-				cy.request({
-					method: 'PATCH',
-					url: compoundURL,
-					body: {locations: locationWithNoCoordinates},
-					failOnStatusCode: false
-				}).should((response) => {
-					expect(response.status).to.be.eq(500);
-					expect(response.body.error).to.be.an('boolean');
-					expect(response.body.error).to.be.eq(true);
-					expect(response.body.message).to.be.eq(
-						'Longitude and Latitude are required fields'
-					);
-				});
+				//hotfix - https://app.asana.com/0/1132189118126148/1201710885977989
+				//defaulting goecode so don't need this test at the moment
+				// cy.request({
+				// 	method: 'PATCH',
+				// 	url: compoundURL,
+				// 	body: {locations: locationWithNoCoordinates},
+				// 	failOnStatusCode: false
+				// }).should((response) => {
+				// 	expect(response.status).to.be.eq(500);
+				// 	expect(response.body.error).to.be.an('boolean');
+				// 	expect(response.body.error).to.be.eq(true);
+				// 	expect(response.body.message).to.be.eq(
+				// 		'Longitude and Latitude are required fields'
+				// 	);
+				// });
 			});
 		});
 	});

--- a/src/routes/organizations.js
+++ b/src/routes/organizations.js
@@ -237,10 +237,11 @@ export const updateOrg = async (req, res) => {
 		}
 		body.locations.map((location) => updateLocationGeolocation(location, res));
 		//Validate Geolocation
-		if (!validateLocationGeolocation(body.locations)) {
-			handleErr({message: 'Longitude and Latitude are required fields'}, res);
-			return;
-		}
+		//commenting out - hot fix - https://app.asana.com/0/1132189118126148/1201710885977986
+		// if (!validateLocationGeolocation(body.locations)) {
+		// 	handleErr({message: 'Longitude and Latitude are required fields'}, res);
+		// 	return;
+		// }
 	}
 
 	await Organization.findOneAndUpdate(
@@ -407,7 +408,12 @@ export const shareOrganization = async (req, res) => {
 const updateLocationGeolocation = (location) => {
 	location.geolocation = {
 		type: 'Point',
-		coordinates: [parseFloat(location.long), parseFloat(location.lat)]
+		//hot fix https://app.asana.com/0/1132189118126148/1201710885977986
+		// coordinates: [parseFloat(location.long), parseFloat(location.lat)]
+		coordinates: [
+			parseFloat(location.long ? location.long : 0),
+			parseFloat(location.lat ? location.lat : 0)
+		]
 	};
 	return location;
 };


### PR DESCRIPTION
## Description
if an organization has more than one address that does not have lat/long already specified, you can’t save your changes because even if you add a lat/long to one address, there is still an error because the other address don’t have a lat/long specified. The backend service verifies all locations  for that organization whenever you try to save any organization data.

with this change - the backend will default geocode to 0 if lat/long not set

in this way, the geocode is set to 0 but the lat/long is set to null. so it’s possible to query for no lat/log set and still find records that need to be updated.

also, with this change - no error message is sent to the screen - the save should always succeed

- Asana ticket:
https://app.asana.com/0/1132189118126148/1201710885977989

## PR Checklist

<!-- Please validate your changes with the checklist below before marking for code review. -->

- [ ] Assign @FJKhan **and** @Alfredo-Moreira as reviewers.
- [ ] If your PR is not a hotfix, is it targeted for `dev`?
- [ ] Unit and functional test coverage was added where applicable.
- [ ] CI/CD passes for your PR.
- [ ] Complex code is well documented with comments.
- [ ] Does the original ticket have test instructions? If not add them below

## How to Test
1. pick an org that has at least one address without lat/long set
2. change something, anything really - just don't provide a lat/long value
3. save those changes
4. verify changes were saved
5. verify there is no error message
